### PR TITLE
Add explicit MyBatis session configuration

### DIFF
--- a/backend/src/main/java/com/digiledger/backend/config/MyBatisConfig.java
+++ b/backend/src/main/java/com/digiledger/backend/config/MyBatisConfig.java
@@ -1,0 +1,33 @@
+package com.digiledger.backend.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan("com.digiledger.backend.mapper")
+public class MyBatisConfig {
+
+    private static final String MAPPER_LOCATION_PATTERN = "classpath:/mapper/*.xml";
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean factoryBean = new SqlSessionFactoryBean();
+        factoryBean.setDataSource(dataSource);
+        factoryBean.setMapperLocations(
+                new PathMatchingResourcePatternResolver().getResources(MAPPER_LOCATION_PATTERN)
+        );
+        return factoryBean.getObject();
+    }
+
+    @Bean
+    public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+        return new SqlSessionTemplate(sqlSessionFactory);
+    }
+}


### PR DESCRIPTION
## Summary
- add an explicit MyBatis configuration that registers the mapper package
- provide SqlSessionFactory and SqlSessionTemplate beans backed by the application DataSource

## Testing
- mvn -q -DskipTests package *(fails: unable to download dependencies due to HTTP 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e325412c832abe1591c0b9f8e556)