### PR TITLE
Refresh frontend to white-green UI

### DIFF
--- a/frontend/src/components/AppLayout.vue
+++ b/frontend/src/components/AppLayout.vue
@@ -67,12 +67,15 @@ const currentTheme = computed({
 
 .layout {
   min-height: 100vh;
+  background: var(--color-bg);
 }
 
 .sidebar {
   background: var(--color-sidebar-bg);
   color: var(--color-sidebar-text);
-  padding: 16px 0;
+  padding: 18px 0 12px;
+  border-right: 1px solid #e5e7eb;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.06);
 }
 
 .logo {
@@ -80,7 +83,8 @@ const currentTheme = computed({
   font-size: 20px;
   font-weight: bold;
   text-align: center;
-  margin-bottom: 16px;
+  margin-bottom: 18px;
+  letter-spacing: 0.5px;
 }
 
 .header {
@@ -90,12 +94,14 @@ const currentTheme = computed({
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 24px;
+  padding: 12px 24px;
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
 }
 
 .main {
   background: var(--color-bg-alt);
-  padding: 24px;
+  padding: 28px;
 }
 
 .main :deep(.el-card) {
@@ -111,15 +117,20 @@ const currentTheme = computed({
 .sidebar :deep(.el-menu) {
   border-right: none;
   background: transparent;
+  padding: 0 12px;
 }
 
 .sidebar :deep(.el-menu-item.is-active) {
-  background: var(--color-accent-soft);
+  background: linear-gradient(120deg, rgba(5, 150, 105, 0.16), rgba(5, 150, 105, 0.08));
   color: var(--color-accent);
+  border-radius: 12px;
+  margin: 0 6px;
 }
 
 .sidebar :deep(.el-menu-item) {
-  color: var(--color-muted);
+  color: #4b5563;
+  border-radius: 12px;
+  height: 44px;
 }
 
 .header-actions {
@@ -129,11 +140,12 @@ const currentTheme = computed({
 }
 
 .theme-select {
-  min-width: 120px;
+  min-width: 140px;
 }
 
 .header-title {
-  font-weight: 600;
+  font-weight: 700;
+  color: var(--color-text);
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/components/AssetCard.vue
+++ b/frontend/src/components/AssetCard.vue
@@ -6,7 +6,14 @@
   >
     <div class="card-header">
       <div class="status-label">
-        <el-tag size="small">{{ asset.status }}</el-tag>
+        <el-tag
+          size="small"
+          round
+          disable-transitions
+          :style="statusStyle"
+        >
+          {{ asset.status }}
+        </el-tag>
       </div>
       <el-checkbox v-if="selectable" :model-value="selected" @change="toggleSelect" />
     </div>
@@ -85,6 +92,17 @@ const fallback = computed(
 
 const coverUrl = computed(() => buildOssUrl(props.asset.coverImageUrl))
 
+const statusStyle = computed(() => {
+  const palette: Record<string, { backgroundColor: string; color: string; borderColor: string }> = {
+    使用中: { backgroundColor: '#d1fae5', color: '#065f46', borderColor: '#bbf7d0' },
+    已闲置: { backgroundColor: '#ecfeff', color: '#0ea5e9', borderColor: '#bae6fd' },
+    待出售: { backgroundColor: '#fef9c3', color: '#92400e', borderColor: '#fef08a' },
+    已出售: { backgroundColor: '#ffe4e6', color: '#be123c', borderColor: '#fecdd3' },
+    已丢弃: { backgroundColor: '#f3f4f6', color: '#374151', borderColor: '#e5e7eb' }
+  }
+  return palette[props.asset.status] || { backgroundColor: '#ecfeff', color: '#0f172a', borderColor: '#bae6fd' }
+})
+
 const formatNumber = (value: number | undefined) => {
   if (!value && value !== 0) return '0.00'
   return value.toFixed(2)
@@ -110,17 +128,18 @@ const handleCoverClick = () => {
 </script>
 
 <style scoped>
+
 .asset-card {
   position: relative;
-  background: linear-gradient(160deg, rgba(30, 64, 175, 0.35), rgba(8, 47, 73, 0.65));
-  border: 1px solid rgba(56, 189, 248, 0.24);
-  border-radius: 18px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
   padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 12px;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
   cursor: default;
 }
 
@@ -151,13 +170,13 @@ const handleCoverClick = () => {
 
 .asset-card:hover {
   transform: translateY(-4px);
-  border-color: rgba(94, 234, 212, 0.6);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.55);
+  border-color: rgba(5, 150, 105, 0.35);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.12);
 }
 
 .asset-card.selected {
-  border-color: #22d3ee;
-  box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.45);
+  border-color: rgba(5, 150, 105, 0.45);
+  box-shadow: 0 0 0 2px rgba(5, 150, 105, 0.18);
 }
 
 .card-header {
@@ -175,8 +194,8 @@ const handleCoverClick = () => {
   aspect-ratio: 4 / 3;
   border-radius: 14px;
   overflow: hidden;
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(145deg, #ecfeff, #e0f2fe);
+  border: 1px dashed rgba(5, 150, 105, 0.3);
   cursor: pointer;
   position: relative;
 }
@@ -190,7 +209,7 @@ const handleCoverClick = () => {
 .cover-empty {
   position: absolute;
   inset: 0;
-  background: rgba(15, 23, 42, 0.72);
+  background: rgba(255, 255, 255, 0.8);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -206,23 +225,23 @@ const handleCoverClick = () => {
 .title {
   font-size: 18px;
   font-weight: 600;
-  color: #f8fafc;
+  color: #0f172a;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .price {
-  color: #22d3ee;
-  font-size: 16px;
-  font-weight: 500;
+  color: #059669;
+  font-size: 18px;
+  font-weight: 700;
 }
 
 .meta {
   display: flex;
   justify-content: space-between;
   font-size: 12px;
-  color: #94a3b8;
+  color: #6b7280;
 }
 
 .tags {
@@ -232,7 +251,7 @@ const handleCoverClick = () => {
 }
 
 .tag {
-  border-radius: 20px;
+  border-radius: 18px;
 }
 
 .tag-icon {
@@ -253,7 +272,7 @@ const handleCoverClick = () => {
 }
 
 .actions :deep(.el-button.is-text) {
-  color: #38bdf8;
+  color: #059669;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/ThemeProvider.vue
+++ b/frontend/src/components/ThemeProvider.vue
@@ -10,15 +10,15 @@ const STORAGE_KEY = 'digiledger-theme'
 
 const themeVariables: Record<ThemeName, Record<string, string>> = {
   light: {
-    'color-bg': '#f8fafc',
-    'color-bg-alt': '#e2e8f0',
-    'color-header-bg': '#f1f5f9',
+    'color-bg': '#f9fafb',
+    'color-bg-alt': '#f3f4f6',
+    'color-header-bg': '#ffffff',
     'color-sidebar-bg': '#ffffff',
-    'color-sidebar-text': '#475569',
-    'color-text': '#0f172a',
-    'color-muted': '#64748b',
-    'color-accent': '#2563eb',
-    'color-accent-soft': 'rgba(37, 99, 235, 0.12)',
+    'color-sidebar-text': '#1f2937',
+    'color-text': '#111827',
+    'color-muted': '#6b7280',
+    'color-accent': '#059669',
+    'color-accent-soft': '#d1fae5',
     'color-card': '#ffffff'
   },
   dark: {
@@ -53,7 +53,7 @@ const options: ThemeOption[] = [
   { label: '霓虹', value: 'neon' }
 ]
 
-const theme = ref<ThemeName>('dark')
+const theme = ref<ThemeName>('light')
 
 if (typeof window !== 'undefined') {
   const stored = localStorage.getItem(STORAGE_KEY) as ThemeName | null

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,15 +1,22 @@
 :root {
   font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
-  --color-bg: #0f172a;
-  --color-bg-alt: #0f172a;
-  --color-header-bg: #1e293b;
-  --color-sidebar-bg: #111827;
-  --color-sidebar-text: #94a3b8;
-  --color-text: #e2e8f0;
-  --color-muted: #cbd5f5;
-  --color-accent: #38bdf8;
-  --color-accent-soft: rgba(56, 189, 248, 0.2);
-  --color-card: #1e293b;
+  --color-bg: #f9fafb;
+  --color-bg-alt: #f3f4f6;
+  --color-header-bg: #ffffff;
+  --color-sidebar-bg: #ffffff;
+  --color-sidebar-text: #1f2937;
+  --color-text: #0f172a;
+  --color-muted: #6b7280;
+  --color-accent: #059669;
+  --color-accent-soft: #d1fae5;
+  --color-card: #ffffff;
+  --el-color-primary: #059669;
+  --el-color-primary-light-3: #34d399;
+  --el-color-primary-light-5: #6ee7b7;
+  --el-color-primary-light-7: #a7f3d0;
+  --el-color-primary-light-8: #d1fae5;
+  --el-color-primary-light-9: #ecfdf3;
+  --el-color-primary-dark-2: #047857;
 }
 
 body, html, #app {

--- a/frontend/src/views/AssetOverview.vue
+++ b/frontend/src/views/AssetOverview.vue
@@ -32,11 +32,11 @@
             <polyline
               :points="trendPoints"
               fill="none"
-              stroke="#22d3ee"
+              stroke="#059669"
               stroke-width="2"
               stroke-linecap="round"
             />
-            <polygon :points="trendArea" fill="rgba(34, 211, 238, 0.15)" />
+            <polygon :points="trendArea" fill="rgba(5, 150, 105, 0.14)" />
           </svg>
           <div class="trend-text">
             <strong>{{ purchasesInWindow }}</strong>
@@ -275,22 +275,22 @@ watch(activeTab, () => {
   align-items: flex-start;
   gap: 16px;
   padding: 28px;
-  border-radius: 20px;
-  background: radial-gradient(circle at top left, rgba(14, 165, 233, 0.32), rgba(15, 23, 42, 0.8));
-  border: 1px solid rgba(56, 189, 248, 0.35);
-  box-shadow: inset 0 0 80px rgba(15, 118, 110, 0.25);
+  border-radius: 24px;
+  background: linear-gradient(140deg, #ffffff, #ecfdf3);
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
 }
 
 .hero h1 {
   margin: 0 0 8px;
   font-size: 32px;
   font-weight: 700;
-  color: #f1f5f9;
+  color: #065f46;
 }
 
 .hero p {
   margin: 0;
-  color: #94a3b8;
+  color: #4b5563;
 }
 
 .hero-actions {
@@ -306,14 +306,15 @@ watch(activeTab, () => {
 }
 
 .kpi-card {
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(34, 211, 238, 0.25);
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: 18px;
-  color: #e2e8f0;
+  color: #0f172a;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
 }
 
 .kpi-label {
-  color: #94a3b8;
+  color: #6b7280;
   font-size: 14px;
 }
 
@@ -321,12 +322,12 @@ watch(activeTab, () => {
   margin-top: 8px;
   font-size: 28px;
   font-weight: 600;
-  color: #22d3ee;
+  color: #059669;
 }
 
 .kpi-desc {
   margin-top: 6px;
-  color: #64748b;
+  color: #6b7280;
 }
 
 .kpi-trend {
@@ -345,18 +346,19 @@ watch(activeTab, () => {
   display: flex;
   flex-direction: column;
   font-size: 12px;
-  color: #94a3b8;
+  color: #6b7280;
 }
 
 .trend-text strong {
   font-size: 18px;
-  color: #f8fafc;
+  color: #065f46;
 }
 
 .category-card {
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(59, 130, 246, 0.25);
-  border-radius: 20px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 22px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
 }
 
 .category-header {
@@ -368,7 +370,7 @@ watch(activeTab, () => {
 }
 
 .tabs :deep(.el-button--primary) {
-  background: linear-gradient(135deg, #1d4ed8, #38bdf8);
+  background: linear-gradient(130deg, #059669, #10b981);
   border-color: transparent;
 }
 
@@ -377,8 +379,9 @@ watch(activeTab, () => {
 }
 
 .quick-search :deep(.el-input__wrapper) {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 .asset-grid {

--- a/frontend/src/views/assets/AssetList.vue
+++ b/frontend/src/views/assets/AssetList.vue
@@ -111,7 +111,7 @@
         <el-table-column label="状态" width="110">
           <template #default="{ row }">
             <div class="cell-center">
-              <el-tag size="small">{{ row.status }}</el-tag>
+              <el-tag size="small" round :style="statusTagStyle(row.status)">{{ row.status }}</el-tag>
             </div>
           </template>
         </el-table-column>
@@ -137,12 +137,24 @@
             <span v-if="!row.tags.length">-</span>
           </template>
         </el-table-column>
-        <el-table-column label="操作" width="260">
+        <el-table-column label="操作" width="210">
           <template #default="{ row }">
             <div class="row-actions">
-              <el-button link type="primary" @click="viewDetail(row.id)">详情</el-button>
-              <el-button link @click="openEdit(row.id)">编辑</el-button>
-              <el-button v-if="row.status !== '已出售'" link type="success" @click="openSell(row)">出售</el-button>
+              <el-tooltip content="详情" placement="top">
+                <el-button circle text type="primary" @click="viewDetail(row.id)">
+                  <el-icon><View /></el-icon>
+                </el-button>
+              </el-tooltip>
+              <el-tooltip content="编辑" placement="top">
+                <el-button circle text @click="openEdit(row.id)">
+                  <el-icon><EditPen /></el-icon>
+                </el-button>
+              </el-tooltip>
+              <el-tooltip v-if="row.status !== '已出售'" content="出售" placement="top">
+                <el-button circle text type="success" @click="openSell(row)">
+                  <el-icon><Tickets /></el-icon>
+                </el-button>
+              </el-tooltip>
 
               <el-dropdown
                 v-if="row.status !== '已出售'"
@@ -151,7 +163,11 @@
                 @command="(value) => handleStatusCommand(row, value as AssetStatus)"
               >
                 <span class="status-action">
-                  <el-button link type="warning">修改状态</el-button>
+                  <el-tooltip content="修改状态" placement="top">
+                    <el-button circle text type="warning">
+                      <el-icon><More /></el-icon>
+                    </el-button>
+                  </el-tooltip>
                 </span>
                 <template #dropdown>
                   <el-dropdown-menu>
@@ -169,7 +185,9 @@
 
               <el-popconfirm title="确认删除该物品？" @confirm="remove(row.id)">
                 <template #reference>
-                  <el-button link type="danger">删除</el-button>
+                  <el-button circle text type="danger">
+                    <el-icon><Delete /></el-icon>
+                  </el-button>
                 </template>
               </el-popconfirm>
             </div>
@@ -191,15 +209,21 @@
           @suggest-cover="openCoverSuggestionDialog"
         >
           <template #actions>
-            <el-button text size="small" type="primary" @click.stop="viewDetail(item.id)">详情</el-button>
-            <el-button text size="small" @click.stop="openEdit(item.id)">编辑</el-button>
-            <el-button
-              v-if="item.status !== '已出售'"
-              text
-              size="small"
-              type="success"
-              @click.stop="openSell(item)"
-            >出售</el-button>
+            <el-tooltip content="详情" placement="top">
+              <el-button text size="small" type="primary" circle @click.stop="viewDetail(item.id)">
+                <el-icon><View /></el-icon>
+              </el-button>
+            </el-tooltip>
+            <el-tooltip content="编辑" placement="top">
+              <el-button text size="small" circle @click.stop="openEdit(item.id)">
+                <el-icon><EditPen /></el-icon>
+              </el-button>
+            </el-tooltip>
+            <el-tooltip v-if="item.status !== '已出售'" content="出售" placement="top">
+              <el-button text size="small" type="success" circle @click.stop="openSell(item)">
+                <el-icon><Tickets /></el-icon>
+              </el-button>
+            </el-tooltip>
             <el-dropdown
               v-if="item.status !== '已出售'"
               trigger="click"
@@ -207,7 +231,11 @@
               @command="(value) => handleStatusCommand(item, value as AssetStatus)"
             >
               <span class="status-action">
-                <el-button text size="small" type="warning">修改状态</el-button>
+                <el-tooltip content="修改状态" placement="top">
+                  <el-button text size="small" type="warning" circle>
+                    <el-icon><More /></el-icon>
+                  </el-button>
+                </el-tooltip>
               </span>
               <template #dropdown>
                 <el-dropdown-menu>
@@ -245,7 +273,7 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Plus, Search } from '@element-plus/icons-vue'
+import { Delete, EditPen, More, Plus, Search, Tickets, View } from '@element-plus/icons-vue'
 import IconRenderer from '@/components/IconRenderer.vue'
 import {
   fetchAssets,
@@ -285,6 +313,17 @@ const filters = reactive({
 
 const statuses: AssetStatus[] = ['使用中', '已闲置', '待出售', '已出售', '已丢弃']
 const editableStatuses: AssetStatus[] = ['使用中', '已闲置', '待出售', '已丢弃']
+
+const statusTagStyle = (status: AssetStatus) => {
+  const map: Record<AssetStatus, { backgroundColor: string; color: string; borderColor: string }> = {
+    使用中: { backgroundColor: '#d1fae5', color: '#065f46', borderColor: '#bbf7d0' },
+    已闲置: { backgroundColor: '#ecfeff', color: '#0ea5e9', borderColor: '#bae6fd' },
+    待出售: { backgroundColor: '#fef9c3', color: '#92400e', borderColor: '#fef08a' },
+    已出售: { backgroundColor: '#ffe4e6', color: '#be123c', borderColor: '#fecdd3' },
+    已丢弃: { backgroundColor: '#f3f4f6', color: '#374151', borderColor: '#e5e7eb' }
+  }
+  return map[status]
+}
 
 const resolveBrandText = (brand?: BrandInfo | null) => {
   const alias = brand?.alias?.trim()
@@ -718,11 +757,15 @@ onMounted(async () => {
 .asset-page {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
 }
 
 .status-card {
-  padding: 6px 12px;
+  padding: 8px 12px;
+  background: #ecfdf3;
+  border: 1px solid #d1fae5;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  border-radius: 14px;
 }
 
 .status-tabs :deep(.el-tabs__header) {
@@ -758,6 +801,21 @@ onMounted(async () => {
   flex-wrap: wrap;
   gap: 12px;
   align-items: flex-end;
+}
+
+.filter-form :deep(.el-input__wrapper),
+.filter-form :deep(.el-select .el-input__wrapper),
+.filter-form :deep(.el-cascader .el-input__wrapper) {
+  border-radius: 12px;
+  border-color: #e5e7eb;
+  background-color: #f9fafb;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.filter-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
 }
 
 .filter-input {
@@ -805,8 +863,11 @@ onMounted(async () => {
   flex-wrap: wrap;
 }
 .row-actions :deep(.el-button) {
-  padding: 0 8px;
-  height: auto;
+  padding: 6px;
+  height: 32px;
+}
+.row-actions :deep(.el-button .el-icon) {
+  font-size: 16px;
 }
 
 .tag-item {

--- a/frontend/src/views/assets/components/AssetForm.vue
+++ b/frontend/src/views/assets/components/AssetForm.vue
@@ -2,278 +2,328 @@
   <div>
     <el-dialog
       v-model="visible"
-      :title="isEdit ? '编辑物品' : '新建物品'"
-      width="760px"
+      :title="null"
+      width="820px"
+      class="asset-dialog"
       @closed="reset"
       destroy-on-close
     >
-    <el-form ref="formRef" :model="form" :rules="rules" label-width="110px" status-icon>
-      <el-row :gutter="16">
-        <el-col :xs="24" :md="12">
-          <el-form-item label="物品名称" prop="name">
-            <el-input v-model="form.name" placeholder="请输入物品名称" />
-          </el-form-item>
-        </el-col>
-        <el-col :xs="24" :md="12">
-          <el-form-item label="物品类别" prop="categoryId" class="with-extra">
-            <el-cascader
-              v-model="form.categoryId"
-              :options="categoryOptions"
-              :props="cascaderProps"
-              clearable
-              placeholder="请选择类别"
-              style="width: 80%"
-            />
-            <el-button
-              class="inline-action"
-              text
-              size="small"
-              type="primary"
-              @click="openCategoryDialog"
-            >
-              新建
-            </el-button>
-          </el-form-item>
-        </el-col>
-      </el-row>
-      <el-row :gutter="16">
-        <el-col :xs="24" :md="12">
-          <el-form-item label="品牌">
-            <div class="brand-field">
-              <el-select
-                v-model="form.brandId"
-                filterable
-                clearable
-                placeholder="选择品牌"
-                @change="handleBrandSelect"
-              >
-                <el-option
-                  v-for="item in brandOptions"
-                  :key="item.id"
-                  :label="item.label"
-                  :value="item.id"
-                />
-              </el-select>
-              <el-button
-                class="inline-action"
-                text
-                size="small"
-                type="primary"
-                @click="handleCreateBrand"
-              >
-                新建
-              </el-button>
-            </div>
-            <!-- <p class="brand-hint">可选品牌后调整显示名称，留空表示不记录品牌。</p> -->
-          </el-form-item>
-        </el-col>
-        <el-col :xs="24" :md="12">
-          <el-form-item label="型号">
-            <el-input v-model="form.model" placeholder="型号/配置" />
-          </el-form-item>
-        </el-col>
-      </el-row>
-      <el-row :gutter="16">
-        <el-col :xs="24" :md="12">
-          <el-form-item label="序列号">
-            <el-input v-model="form.serialNo" placeholder="如 SN / IMEI" />
-          </el-form-item>
-        </el-col>
-      </el-row>
-      <el-row :gutter="16">
-        <el-col :xs="24" :md="12">
-          <el-form-item label="购买日期" prop="purchaseDate">
-            <el-date-picker
-              v-model="form.purchaseDate"
-              type="date"
-              value-format="YYYY-MM-DD"
-              :shortcuts="dateShortcuts"
-              placeholder="选择购买日期"
-            />
-          </el-form-item>
-        </el-col>
-        <el-col :xs="24" :md="12">
-          <el-form-item label="标签">
-            <el-tree-select
-              v-model="form.tagIds"
-              :data="tagOptions"
-              :props="treeProps"
-              multiple
-              show-checkbox
-              filterable
-              placeholder="选择标签"
-              style="width: 80%"
-            />
-            <el-button
-              class="inline-action"
-              text
-              size="small"
-              type="primary"
-              @click="handleCreateTag"
-            >
-              新建
-            </el-button>
-          </el-form-item>
-        </el-col>
-      </el-row>
-      <el-form-item label="封面图">
-        <div class="cover-upload">
-          <UnifiedUploader
-            :http-request="handleUpload"
-            :show-file-list="false"
-            accept="image/*"
-            capture="environment"
-            @progress="coverProgress = $event.percent"
-          />
-          <el-progress
-            v-if="coverProgress && coverProgress < 100"
-            :percentage="Math.round(coverProgress)"
-            :stroke-width="4"
-            status="success"
-          />
-          <img v-if="coverImagePreview" :src="coverImagePreview" class="cover" />
-          <div class="cover-actions">
-            <el-button type="text" size="small" :disabled="!form.id" @click="openCoverSuggestionDialog">
-              智能找图设封面
-            </el-button>
-          </div>
+      <div class="dialog-hero">
+        <div>
+          <h3>{{ isEdit ? '编辑物品' : '新建物品' }}</h3>
+          <p>上传封面、补充品牌与购买记录，系统会帮你算出日均成本。</p>
         </div>
-      </el-form-item>
-      <el-form-item label="备注">
-        <el-input v-model="form.notes" type="textarea" rows="3" placeholder="记录特殊说明" />
-      </el-form-item>
-      <div class="section-header">购买记录</div>
-      <el-button type="primary" text @click="addPurchase">添加购买</el-button>
-      <el-empty v-if="!form.purchases.length" description="尚未添加购买记录" />
-      <el-collapse v-else accordion>
-        <el-collapse-item
-          v-for="(purchase, index) in form.purchases"
-          :key="index"
-          :title="`记录 ${index + 1} · ${purchase.type}`"
-        >
-          <el-row :gutter="12">
-            <el-col :xs="24" :md="purchase.type !== 'PRIMARY' ? 6 : 8">
-              <el-select v-model="purchase.type" placeholder="类型" @change="handlePurchaseTypeChange(purchase)">
-                <el-option label="主商品" value="PRIMARY" />
-                <el-option label="配件" value="ACCESSORY" />
-                <el-option label="服务" value="SERVICE" />
-              </el-select>
-            </el-col>
-            <el-col v-if="purchase.type !== 'PRIMARY'" :xs="24" :md="6">
-              <el-input v-model="purchase.name" placeholder="配件/服务名称" />
-            </el-col>
-            <el-col :xs="24" :md="purchase.type !== 'PRIMARY' ? 6 : 8">
-              <el-select
-                v-model="purchase.platformId"
-                placeholder="购买平台"
-                filterable
-                clearable
-                style="width: 80%"
-              >
-                <el-option v-for="item in platforms" :key="item.id" :label="item.name" :value="item.id" />
-              </el-select>
-              <el-button
-                class="inline-action"
-                text
-                size="small"
-                type="primary"
-                @click="handleCreatePlatform(purchase)"
-              >
-                新建
-              </el-button>
-            </el-col>
-            <el-col :xs="24" :md="purchase.type !== 'PRIMARY' ? 6 : 8">
-              金额: <el-input-number v-model="purchase.price" :min="0" :precision="2" :step="100" />
-            </el-col>
-          </el-row>
-          
-          <el-row :gutter="12" class="mt">
-            <el-col v-if="purchase.type !== 'PRIMARY'" :xs="24" :md="8">
-              <el-input-number v-model="purchase.quantity" :min="1" :step="1" />
-            </el-col>
-            <el-col :xs="24" :md="8">
-              <el-input v-model="purchase.seller" placeholder="卖家/店铺" />
-            </el-col>
-          </el-row>
-          <el-row :gutter="12" class="mt">
-            <el-col :xs="24" :md="8">
-              <el-date-picker
-                v-model="purchase.purchaseDate"
-                type="date"
-                value-format="YYYY-MM-DD"
-                :shortcuts="dateShortcuts"
-                placeholder="购买日期"
-                clearable
-                @change="() => syncPurchaseWarranty(purchase)"
+        <el-tag effect="plain" round type="success">物品卡片</el-tag>
+      </div>
+
+      <el-form
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        label-width="auto"
+        label-position="top"
+        status-icon
+        class="asset-form"
+      >
+        <div class="form-grid">
+          <section class="media-panel">
+            <div class="panel-title">封面与备注</div>
+            <el-form-item label="封面图" class="cover-item">
+              <div class="cover-upload">
+                <div class="upload-drop">
+                  <UnifiedUploader
+                    :http-request="handleUpload"
+                    :show-file-list="false"
+                    accept="image/*"
+                    capture="environment"
+                    @progress="coverProgress = $event.percent"
+                  />
+                  <div class="upload-hint">拖拽/点击上传，推荐 3:2 比例</div>
+                </div>
+                <el-progress
+                  v-if="coverProgress && coverProgress < 100"
+                  :percentage="Math.round(coverProgress)"
+                  :stroke-width="4"
+                  status="success"
+                />
+                <img v-if="coverImagePreview" :src="coverImagePreview" class="cover" />
+                <div class="cover-actions">
+                  <el-button
+                    type="primary"
+                    link
+                    size="small"
+                    :disabled="!form.id"
+                    @click="openCoverSuggestionDialog"
+                  >
+                    智能找图设封面
+                  </el-button>
+                </div>
+              </div>
+            </el-form-item>
+            <el-form-item label="备注" class="note-item">
+              <el-input
+                v-model="form.notes"
+                type="textarea"
+                :rows="4"
+                placeholder="记录特殊说明、保养节点或使用心得"
               />
-            </el-col>
-            <el-col :xs="24" :md="8">
-              <el-input-number
-                v-model="purchase.warrantyMonths"
-                :min="0"
-                :step="1"
-                placeholder="质保（月）"
-                controls-position="right"
-                @change="() => syncPurchaseWarranty(purchase)"
-              />
-            </el-col>
-            <el-col :xs="24" :md="8">
-              <el-date-picker
-                v-model="purchase.warrantyExpireDate"
-                type="date"
-                value-format="YYYY-MM-DD"
-                :shortcuts="dateShortcuts"
-                placeholder="质保到期日"
-                disabled
-              />
-            </el-col>
-          </el-row>
-          <el-row :gutter="12" class="mt">
-            <el-col :xs="24">
-              购买链接: <el-input v-model="purchase.productLink" placeholder="购买链接" />
-            </el-col>
-          </el-row>
-          <el-row :gutter="12" class="mt">
-            <el-col :xs="24">
-              备注: <el-input v-model="purchase.notes" placeholder="备注" />
-            </el-col>
-          </el-row>
-          <div class="attachments">
-            <UnifiedUploader :http-request="(options) => uploadAttachment(options, purchase)" :show-file-list="false" accept="image/*" capture="environment" />
-            <div
-              v-for="(url, idx) in purchase.attachments"
-              :key="`${idx}-${url}`"
-              class="attachment-thumb"
-            >
-              <el-image
-                v-if="resolveOssUrl(url)"
-                :src="resolveOssUrl(url)"
-                fit="cover"
-                class="attachment-image"
-                :preview-src-list="[resolveOssUrl(url)]"
-              />
-              <div v-else class="attachment-fallback">附件{{ idx + 1 }}</div>
-              <el-button
-                text
-                type="danger"
-                size="small"
-                class="attachment-remove"
-                @click="removeAttachment(purchase, url)"
-              >
-                删除
-              </el-button>
+            </el-form-item>
+          </section>
+
+          <section class="fields-panel">
+            <div class="panel-title">基础信息</div>
+            <el-row :gutter="16">
+              <el-col :xs="24" :md="12">
+                <el-form-item label="物品名称" prop="name">
+                  <el-input v-model="form.name" placeholder="请输入物品名称" />
+                </el-form-item>
+              </el-col>
+              <el-col :xs="24" :md="12">
+                <el-form-item label="物品类别" prop="categoryId" class="with-extra">
+                  <el-cascader
+                    v-model="form.categoryId"
+                    :options="categoryOptions"
+                    :props="cascaderProps"
+                    clearable
+                    placeholder="请选择类别"
+                    style="width: 100%"
+                  />
+                  <el-button
+                    class="inline-action"
+                    text
+                    size="small"
+                    type="primary"
+                    @click="openCategoryDialog"
+                  >
+                    新建
+                  </el-button>
+                </el-form-item>
+              </el-col>
+            </el-row>
+            <el-row :gutter="16">
+              <el-col :xs="24" :md="12">
+                <el-form-item label="品牌">
+                  <div class="brand-field">
+                    <el-select
+                      v-model="form.brandId"
+                      filterable
+                      clearable
+                      placeholder="选择品牌"
+                      @change="handleBrandSelect"
+                    >
+                      <el-option
+                        v-for="item in brandOptions"
+                        :key="item.id"
+                        :label="item.label"
+                        :value="item.id"
+                      />
+                    </el-select>
+                    <el-button
+                      class="inline-action"
+                      text
+                      size="small"
+                      type="primary"
+                      @click="handleCreateBrand"
+                    >
+                      新建
+                    </el-button>
+                  </div>
+                </el-form-item>
+              </el-col>
+              <el-col :xs="24" :md="12">
+                <el-form-item label="型号">
+                  <el-input v-model="form.model" placeholder="型号/配置" />
+                </el-form-item>
+              </el-col>
+            </el-row>
+            <el-row :gutter="16">
+              <el-col :xs="24" :md="12">
+                <el-form-item label="序列号">
+                  <el-input v-model="form.serialNo" placeholder="如 SN / IMEI" />
+                </el-form-item>
+              </el-col>
+              <el-col :xs="24" :md="12">
+                <el-form-item label="购买日期" prop="purchaseDate">
+                  <el-date-picker
+                    v-model="form.purchaseDate"
+                    type="date"
+                    value-format="YYYY-MM-DD"
+                    :shortcuts="dateShortcuts"
+                    placeholder="选择购买日期"
+                    style="width: 100%"
+                  />
+                </el-form-item>
+              </el-col>
+            </el-row>
+            <el-row :gutter="16">
+              <el-col :xs="24" :md="12">
+                <el-form-item label="标签">
+                  <el-tree-select
+                    v-model="form.tagIds"
+                    :data="tagOptions"
+                    :props="treeProps"
+                    multiple
+                    show-checkbox
+                    filterable
+                    placeholder="选择标签"
+                    style="width: 100%"
+                  />
+                  <el-button
+                    class="inline-action"
+                    text
+                    size="small"
+                    type="primary"
+                    @click="handleCreateTag"
+                  >
+                    新建
+                  </el-button>
+                </el-form-item>
+              </el-col>
+            </el-row>
+          </section>
+        </div>
+
+        <el-card class="purchase-card" shadow="never">
+          <template #header>
+            <div class="purchase-header">
+              <div>
+                <div class="panel-title">购买记录</div>
+                <p class="panel-subtitle">拆分主商品、配件、服务，方便核算投入</p>
+              </div>
+              <el-button type="primary" text @click="addPurchase">添加购买</el-button>
             </div>
-          </div>
-          <div class="purchase-actions">
-            <el-button type="danger" text @click="removePurchase(index)">删除记录</el-button>
-          </div>
-        </el-collapse-item>
-      </el-collapse>
-    </el-form>
-    <template #footer>
-      <el-button @click="visible = false">取消</el-button>
-      <el-button type="primary" :loading="loading" @click="submit">保存</el-button>
-    </template>
+          </template>
+          <el-empty v-if="!form.purchases.length" description="尚未添加购买记录" />
+          <el-collapse v-else accordion>
+            <el-collapse-item
+              v-for="(purchase, index) in form.purchases"
+              :key="index"
+              :title="`记录 ${index + 1} · ${purchase.type}`"
+            >
+              <el-row :gutter="12">
+                <el-col :xs="24" :md="purchase.type !== 'PRIMARY' ? 6 : 8">
+                  <el-select v-model="purchase.type" placeholder="类型" @change="handlePurchaseTypeChange(purchase)">
+                    <el-option label="主商品" value="PRIMARY" />
+                    <el-option label="配件" value="ACCESSORY" />
+                    <el-option label="服务" value="SERVICE" />
+                  </el-select>
+                </el-col>
+                <el-col v-if="purchase.type !== 'PRIMARY'" :xs="24" :md="6">
+                  <el-input v-model="purchase.name" placeholder="配件/服务名称" />
+                </el-col>
+                <el-col :xs="24" :md="purchase.type !== 'PRIMARY' ? 6 : 8">
+                  <el-select
+                    v-model="purchase.platformId"
+                    placeholder="购买平台"
+                    filterable
+                    clearable
+                    style="width: 100%"
+                  >
+                    <el-option v-for="item in platforms" :key="item.id" :label="item.name" :value="item.id" />
+                  </el-select>
+                  <el-button
+                    class="inline-action"
+                    text
+                    size="small"
+                    type="primary"
+                    @click="handleCreatePlatform(purchase)"
+                  >
+                    新建
+                  </el-button>
+                </el-col>
+                <el-col :xs="24" :md="purchase.type !== 'PRIMARY' ? 6 : 8">
+                  金额: <el-input-number v-model="purchase.price" :min="0" :precision="2" :step="100" />
+                </el-col>
+              </el-row>
+
+              <el-row :gutter="12" class="mt">
+                <el-col v-if="purchase.type !== 'PRIMARY'" :xs="24" :md="8">
+                  <el-input-number v-model="purchase.quantity" :min="1" :step="1" />
+                </el-col>
+                <el-col :xs="24" :md="8">
+                  <el-input v-model="purchase.seller" placeholder="卖家/店铺" />
+                </el-col>
+              </el-row>
+              <el-row :gutter="12" class="mt">
+                <el-col :xs="24" :md="8">
+                  <el-date-picker
+                    v-model="purchase.purchaseDate"
+                    type="date"
+                    value-format="YYYY-MM-DD"
+                    :shortcuts="dateShortcuts"
+                    placeholder="购买日期"
+                    clearable
+                    @change="() => syncPurchaseWarranty(purchase)"
+                  />
+                </el-col>
+                <el-col :xs="24" :md="8">
+                  <el-input-number
+                    v-model="purchase.warrantyMonths"
+                    :min="0"
+                    :step="1"
+                    placeholder="质保（月）"
+                    controls-position="right"
+                    @change="() => syncPurchaseWarranty(purchase)"
+                  />
+                </el-col>
+                <el-col :xs="24" :md="8">
+                  <el-date-picker
+                    v-model="purchase.warrantyExpireDate"
+                    type="date"
+                    value-format="YYYY-MM-DD"
+                    :shortcuts="dateShortcuts"
+                    placeholder="质保到期日"
+                    disabled
+                  />
+                </el-col>
+              </el-row>
+              <el-row :gutter="12" class="mt">
+                <el-col :xs="24">
+                  购买链接: <el-input v-model="purchase.productLink" placeholder="购买链接" />
+                </el-col>
+              </el-row>
+              <el-row :gutter="12" class="mt">
+                <el-col :xs="24">
+                  备注: <el-input v-model="purchase.notes" placeholder="备注" />
+                </el-col>
+              </el-row>
+              <div class="attachments">
+                <UnifiedUploader :http-request="(options) => uploadAttachment(options, purchase)" :show-file-list="false" accept="image/*" capture="environment" />
+                <div
+                  v-for="(url, idx) in purchase.attachments"
+                  :key="`${idx}-${url}`"
+                  class="attachment-thumb"
+                >
+                  <el-image
+                    v-if="resolveOssUrl(url)"
+                    :src="resolveOssUrl(url)"
+                    fit="cover"
+                    class="attachment-image"
+                    :preview-src-list="[resolveOssUrl(url)]"
+                  />
+                  <div v-else class="attachment-fallback">附件{{ idx + 1 }}</div>
+                  <el-button
+                    text
+                    type="danger"
+                    size="small"
+                    class="attachment-remove"
+                    @click="removeAttachment(purchase, url)"
+                  >
+                    删除
+                  </el-button>
+                </div>
+              </div>
+              <div class="purchase-actions">
+                <el-button type="danger" text @click="removePurchase(index)">删除记录</el-button>
+              </div>
+            </el-collapse-item>
+          </el-collapse>
+        </el-card>
+      </el-form>
+      <template #footer>
+        <el-button @click="visible = false">取消</el-button>
+        <el-button type="primary" :loading="loading" @click="submit">保存</el-button>
+      </template>
     </el-dialog>
 
     <category-create-dialog
@@ -362,7 +412,7 @@ const form = reactive({
     warrantyMonths?: number
     warrantyExpireDate?: string
     notes?: string
-    productLink?:string
+    productLink?: string
     name?: string
     attachments: string[]
   }>
@@ -744,34 +794,34 @@ const submit = () => {
     try {
       normalizeBrandName()
       const brandText = form.brandName.trim()
-        const payload = {
-          name: form.name,
-          categoryId: form.categoryId!,
-          brandId: form.brandId || undefined,
-          brand: brandText || undefined,
-          model: form.model || undefined,
-          serialNo: form.serialNo || undefined,
-          status: form.status,
-          purchaseDate: form.purchaseDate || undefined,
-          coverImageUrl: extractObjectKey(form.coverImageKey) || undefined,
-          notes: form.notes || undefined,
-          tagIds: form.tagIds,
-          purchases: form.purchases.map((p) => ({
-            type: p.type,
-            platformId: p.platformId,
-            seller: p.seller || undefined,
-            price: p.price,
-            shippingCost: p.shippingCost,
-            quantity: p.quantity,
-            purchaseDate: p.purchaseDate,
-            warrantyMonths: p.warrantyMonths ?? undefined,
-            warrantyExpireDate: p.warrantyExpireDate || undefined,
-            productLink: p.productLink || undefined,
-            notes: p.notes || undefined,
-            name: p.type === 'PRIMARY' ? undefined : p.name,
-            attachments: extractObjectKeys(p.attachments)
-          }))
-        }
+      const payload = {
+        name: form.name,
+        categoryId: form.categoryId!,
+        brandId: form.brandId || undefined,
+        brand: brandText || undefined,
+        model: form.model || undefined,
+        serialNo: form.serialNo || undefined,
+        status: form.status,
+        purchaseDate: form.purchaseDate || undefined,
+        coverImageUrl: extractObjectKey(form.coverImageKey) || undefined,
+        notes: form.notes || undefined,
+        tagIds: form.tagIds,
+        purchases: form.purchases.map((p) => ({
+          type: p.type,
+          platformId: p.platformId,
+          seller: p.seller || undefined,
+          price: p.price,
+          shippingCost: p.shippingCost,
+          quantity: p.quantity,
+          purchaseDate: p.purchaseDate,
+          warrantyMonths: p.warrantyMonths ?? undefined,
+          warrantyExpireDate: p.warrantyExpireDate || undefined,
+          productLink: p.productLink || undefined,
+          notes: p.notes || undefined,
+          name: p.type === 'PRIMARY' ? undefined : p.name,
+          attachments: extractObjectKeys(p.attachments)
+        }))
+      }
       let result: any
       if (customSubmit.value) {
         result = await customSubmit.value(payload)
@@ -806,34 +856,102 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.section-header {
-  margin-top: 16px;
-  margin-bottom: 8px;
-  font-weight: 600;
-  color: #38bdf8;
+.asset-dialog :deep(.el-dialog__body) {
+  padding-top: 4px;
+}
+
+.dialog-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 18px;
+  background: linear-gradient(135deg, #ecfdf3, #ffffff);
+  border: 1px solid #d1fae5;
+  border-radius: 16px;
+  margin-bottom: 16px;
+}
+
+.dialog-hero h3 {
+  margin: 0 0 6px;
+  font-size: 20px;
+  color: #065f46;
+}
+
+.dialog-hero p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 13px;
+}
+
+.asset-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.media-panel,
+.fields-panel {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.panel-title {
+  font-weight: 700;
+  color: #065f46;
+  margin-bottom: 10px;
+}
+
+.panel-subtitle {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 12px;
 }
 
 .cover-upload {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+}
+
+.upload-drop {
+  border: 1px dashed rgba(5, 150, 105, 0.35);
+  border-radius: 14px;
+  padding: 18px;
+  background: #f9fafb;
+  text-align: center;
+  color: #065f46;
+}
+
+.upload-hint {
+  margin-top: 8px;
+  color: #6b7280;
+  font-size: 12px;
 }
 
 .cover {
-  width: 120px;
-  height: 120px;
+  width: 100%;
   border-radius: 12px;
   object-fit: cover;
-  border: 1px solid rgba(56, 189, 248, 0.35);
+  border: 1px solid rgba(5, 150, 105, 0.22);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.note-item :deep(.el-textarea__inner) {
+  border-radius: 12px;
 }
 
 .mt {
   margin-top: 12px;
-}
-
-.tag {
-  margin-right: 6px;
-  margin-top: 4px;
 }
 
 .attachments {
@@ -846,21 +964,22 @@ onMounted(async () => {
 
 .attachment-thumb {
   position: relative;
-  width: 80px;
-  height: 80px;
+  width: 88px;
+  height: 88px;
 }
 
 .attachment-image,
 .attachment-fallback {
   width: 100%;
   height: 100%;
-  border-radius: 8px;
-  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 10px;
+  border: 1px solid rgba(5, 150, 105, 0.2);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 12px;
   color: var(--el-text-color-secondary);
+  background: #f9fafb;
 }
 
 .attachment-remove {
@@ -868,6 +987,18 @@ onMounted(async () => {
   top: -8px;
   right: -6px;
   padding: 0;
+}
+
+.purchase-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.purchase-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .purchase-actions {
@@ -896,23 +1027,6 @@ onMounted(async () => {
   min-width: 0;
 }
 
-.brand-hint {
-  margin: 4px 0 0;
-  font-size: 12px;
-  color: var(--el-text-color-secondary);
-}
-
-@media (max-width: 768px) {
-  .brand-field {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .brand-field :deep(.el-select) {
-    width: 100%;
-  }
-}
-
 .with-extra {
   position: relative;
   padding-bottom: 12px;
@@ -924,7 +1038,22 @@ onMounted(async () => {
   bottom: -6px;
 }
 
+@media (max-width: 960px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
+  .brand-field {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .brand-field :deep(.el-select) {
+    width: 100%;
+  }
+
   :deep(.el-dialog) {
     width: 94vw !important;
   }

--- a/frontend/src/views/settings/components/CategoryManager.vue
+++ b/frontend/src/views/settings/components/CategoryManager.vue
@@ -1,8 +1,29 @@
 <template>
   <div class="category-manager" v-loading="loading">
     <div class="toolbar">
-      <el-button type="primary" @click="addRoot">新增根类别</el-button>
-      <el-button @click="refreshDicts">刷新</el-button>
+      <el-input
+        v-model="filterText"
+        placeholder="搜索分类"
+        clearable
+        size="small"
+        class="toolbar-search"
+      >
+        <template #prefix>
+          <el-icon><Search /></el-icon>
+        </template>
+      </el-input>
+      <div class="toolbar-actions">
+        <el-button text size="small" @click="expandAll">展开全部</el-button>
+        <el-button text size="small" @click="collapseAll">折叠全部</el-button>
+        <el-button text size="small" @click="refreshDicts">
+          <el-icon><Refresh /></el-icon>
+          刷新
+        </el-button>
+        <el-button type="primary" @click="addRoot">
+          <el-icon class="mr-1"><Plus /></el-icon>
+          新增根类别
+        </el-button>
+      </div>
     </div>
     <el-tree
       ref="treeRef"
@@ -11,16 +32,31 @@
       default-expand-all
       draggable
       :props="{ children: 'children', label: 'name' }"
+      :filter-node-method="filterNode"
       empty-text="暂无类别"
       @node-drop="handleDrop"
     >
       <template #default="{ data }">
-        <span class="node-label">{{ data.name }}</span>
-        <span class="node-actions">
-          <el-button link type="primary" @click.stop="addChild(data)">新增子类</el-button>
-          <el-button link @click.stop="editNode(data)">重命名</el-button>
-          <el-button link type="danger" @click.stop="removeNode(data)">删除</el-button>
-        </span>
+        <div class="node-row">
+          <span class="node-label">{{ data.name }}</span>
+          <span class="node-actions">
+            <el-tooltip content="新增子类" placement="top">
+              <el-button circle text type="success" @click.stop="addChild(data)">
+                <el-icon><Plus /></el-icon>
+              </el-button>
+            </el-tooltip>
+            <el-tooltip content="重命名" placement="top">
+              <el-button circle text @click.stop="editNode(data)">
+                <el-icon><EditPen /></el-icon>
+              </el-button>
+            </el-tooltip>
+            <el-tooltip content="删除" placement="top">
+              <el-button circle text type="danger" @click.stop="removeNode(data)">
+                <el-icon><Delete /></el-icon>
+              </el-button>
+            </el-tooltip>
+          </span>
+        </div>
       </template>
     </el-tree>
     <CategoryCreateDialog
@@ -32,8 +68,9 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { Delete, EditPen, Plus, Refresh, Search } from '@element-plus/icons-vue'
 import { updateCategory, deleteCategory, type CategoryNode } from '@/api/dict'
 import { useDictionaries } from '@/composables/useDictionaries'
 import CategoryCreateDialog from '@/components/CategoryCreateDialog.vue'
@@ -43,6 +80,7 @@ const loading = ref(false)
 const treeRef = ref()
 const createDialogVisible = ref(false)
 const createDialogParentId = ref<number | null>(null)
+const filterText = ref('')
 
 const promptName = async (title: string, defaultValue = ''): Promise<string | null> => {
   try {
@@ -58,10 +96,31 @@ const promptName = async (title: string, defaultValue = ''): Promise<string | nu
   }
 }
 
+const handleFilter = (value: string) => {
+  const tree = treeRef.value as any
+  tree?.filter(value)
+}
+
+const filterNode = (value: string, data: CategoryNode) => {
+  if (!value) return true
+  return data.name.toLowerCase().includes(value.toLowerCase())
+}
+
 const openCreateDialog = (parentId: number | null) => {
   createDialogParentId.value = parentId
   createDialogVisible.value = true
 }
+
+const toggleAll = (expand: boolean) => {
+  const tree = treeRef.value as any
+  if (!tree?.store?.nodesMap) return
+  Object.values(tree.store.nodesMap).forEach((node: any) => {
+    node.expanded = expand
+  })
+}
+
+const expandAll = () => toggleAll(true)
+const collapseAll = () => toggleAll(false)
 
 const addRoot = () => {
   openCreateDialog(null)
@@ -149,21 +208,39 @@ const handleCreateSuccess = (payload: { id: number }) => {
 }
 
 loadDicts()
+
+watch(filterText, (value) => handleFilter(value))
 </script>
 
 <style scoped>
 .category-manager {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 12px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
   padding: 16px;
   min-height: 360px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
 }
 
 .toolbar {
   display: flex;
   gap: 12px;
   margin-bottom: 16px;
+  align-items: center;
+}
+
+.toolbar-search {
+  max-width: 240px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.toolbar-actions :deep(.el-button--primary) {
+  border-radius: 10px;
 }
 
 .node-label {
@@ -171,8 +248,20 @@ loadDicts()
 }
 
 .node-actions {
-  margin-left: 12px;
   display: inline-flex;
-  gap: 8px;
+  gap: 6px;
+}
+
+.node-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 10px;
+  transition: background-color 0.2s ease;
+}
+
+.node-row:hover {
+  background: #ecfdf3;
 }
 </style>


### PR DESCRIPTION
## Summary
- switch the app theme to the new white/green palette and adjust layout chrome accordingly
- refresh dashboard, asset list/cards, and asset form styling to match the new design direction
- modernize category manager with search, hover actions, and expand/collapse controls

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694105e2ddfc832aa735d59232e23059)